### PR TITLE
Add resume word analysis notebook and figures

### DIFF
--- a/quiz1/Q2-code.ipynb
+++ b/quiz1/Q2-code.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Resume Word Analysis\n",
+    "This notebook analyzes the frequency of words in a resume and visualizes the top terms before and after removing stop words."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "from collections import Counter\n",
+    "from pathlib import Path\n",
+    "\n",
+    "resume_path = Path('Q2/data/suprawee_resume.txt')\n",
+    "stop_words_path = Path('Q2/data/stop_words.txt')\n",
+    "figures_dir = Path('Q2/figures')\n",
+    "figures_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def save_svg_bar(data, filename, title):\n",
+    "    width = 800\n",
+    "    height = 400\n",
+    "    bar_width = width / len(data)\n",
+    "    max_count = max(count for _, count in data)\n",
+    "    scale = (height - 50) / max_count\n",
+    "    svg_parts = [f'<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{height}\">']\n",
+    "    svg_parts.append(f'<text x=\"{width/2}\" y=\"20\" text-anchor=\"middle\" font-size=\"16\" fill=\"white\">{title}</text>')\n",
+    "    for i, (word, count) in enumerate(data):\n",
+    "        x = i * bar_width\n",
+    "        bar_height = count * scale\n",
+    "        y = height - bar_height - 20\n",
+    "        svg_parts.append(f'<rect x=\"{x}\" y=\"{y}\" width=\"{bar_width-2}\" height=\"{bar_height}\" fill=\"steelblue\"/>')\n",
+    "        svg_parts.append(f'<text x=\"{x + bar_width/2}\" y=\"{height - 5}\" text-anchor=\"middle\" font-size=\"10\" transform=\"rotate(45 {x + bar_width/2},{height - 5})\" fill=\"white\">{word}</text>')\n",
+    "    svg_parts.append('</svg>')\n",
+    "    Path(filename).write_text('\n'.join(svg_parts), encoding='utf-8')\n",
+    "\n",
+    "text = resume_path.read_text(encoding='utf-8')\n",
+    "words = re.findall(r'\\b\\w+\\b', text.lower())\n",
+    "word_counts = Counter(words)\n",
+    "top_resume = word_counts.most_common(20)\n",
+    "save_svg_bar(top_resume, figures_dir/'resume_words.svg', 'Top 20 Resume Words')\n",
+    "top_resume[:5]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stop_words = set(stop_words_path.read_text(encoding='utf-8').split())\n",
+    "specific_words = [w for w in words if w not in stop_words]\n",
+    "specific_counts = Counter(specific_words)\n",
+    "top_specific = specific_counts.most_common(20)\n",
+    "save_svg_bar(top_specific, figures_dir/'specific_words.svg', 'Top 20 Specific Words')\n",
+    "top_specific[:5]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Removing common stop words reveals keywords that emphasize technical skills and experiences, such as **developed**, **python**, and **project**, giving more insight into the resume's content."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/quiz1/Q2/data/suprawee_resume.txt
+++ b/quiz1/Q2/data/suprawee_resume.txt
@@ -1,0 +1,41 @@
+Suprawee Pongpeeradech
+
+Columbia, SC 29201 | ty.suprawee@gmail.com | LinkedIn.com/in/supraweeUSC
+EDUCATION
+University of South Carolina - Columbia, SC Jan 2023 - Current
+Bachelor of Science in Computer Engineering (Expected December 2025) GPA: 3.89
+• President’s Honor Lists, Dean's Honor Lists, Scholarships
+Kasetsart University - Bangkok, Thailand 2020 – 2022
+Bachelor of Science in Software & Knowledge Engineering
+WORK & LEADERSHIP EXPERIENCE
+Undergraduate Assistant | HTML, CSS, Javascript, Python August 2023 - Present
+• Conducts computer lab sessions and assists students with assignments in HTML and Python.
+• Provides debugging support and guidance on programming concepts.
+Organization of Thai Sport Week August 2020
+Managed venue setup, sports equipment, and scheduling for over 300 athletes.
+• Oversaw event logistics, ensuring smooth competition flow.
+• Hosted the event and provided real-time coordination for athletes and sports categories.
+PROJECTS
+Music Streaming Web Application Capstone | React, Spring Boot, SQL 2024 – 2025
+• Developed a full-stack music streaming platform with user authentication, playlist management, and
+real-time audio streaming.
+• Designed an intuitive UI for seamless navigation and personalized music recommendations.
+• Implemented backend services for secure data storage and efficient content delivery.
+Data Assistant Analysis Software | Python, Pandas, Tkinter, SQL 2022
+• Developed a Python-based GUI program to analyze customer behavior from over 10 million records.
+• Utilized data visualization tools to generate insights for improved business decision-making.
+Shooting Game Development | C#, Unity, Physics Engine 2022
+• Designed and developed a shooting game incorporating real-world physics for improved aiming
+mechanics.
+Smart Café Project | Python, SQL, Database Management 2019 – 2020
+• Developed an automated system to manage internet usage based on customers' Wi-Fi hours and
+purchase history.
+• Implemented database-driven analytics to optimize pricing strategies.
+CanSat Thailand Competition 2019 (Top 50 Finalizst) | MATLAB, Python, 3D Maker Software 2019
+• Designed and simulated a 3D bottle rocket model to analyze projectile motion.
+• Performed force calculations to optimize aerodynamic performance before launch
+SKILLS
+Languages: Proficient in Python, Java, C#/C++; Familiar with SQL
+Software: Excel, Microsoft Access, Git, Linux, VS Code, Jupyter Notebook
+Frameworks: ROS, MATLAB, Verilog, React
+Skills: Leadership, Teamwork, Problem-solving

--- a/quiz1/Q2/figures/resume_words.svg
+++ b/quiz1/Q2/figures/resume_words.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">
+<text x="400.0" y="20" text-anchor="middle" font-size="16" fill="white">Top 20 Resume Words</text>
+<rect x="0.0" y="30.0" width="38.0" height="350.0" fill="steelblue"/>
+<text x="20.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 20.0,395)" fill="white">and</text>
+<rect x="40.0" y="175.83333333333331" width="38.0" height="204.16666666666669" fill="steelblue"/>
+<text x="60.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 60.0,395)" fill="white">python</text>
+<rect x="80.0" y="205.0" width="38.0" height="175.0" fill="steelblue"/>
+<text x="100.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 100.0,395)" fill="white">for</text>
+<rect x="120.0" y="205.0" width="38.0" height="175.0" fill="steelblue"/>
+<text x="140.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 140.0,395)" fill="white">to</text>
+<rect x="160.0" y="234.16666666666666" width="38.0" height="145.83333333333334" fill="steelblue"/>
+<text x="180.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 180.0,395)" fill="white">in</text>
+<rect x="200.0" y="263.3333333333333" width="38.0" height="116.66666666666667" fill="steelblue"/>
+<text x="220.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 220.0,395)" fill="white">of</text>
+<rect x="240.0" y="263.3333333333333" width="38.0" height="116.66666666666667" fill="steelblue"/>
+<text x="260.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 260.0,395)" fill="white">software</text>
+<rect x="280.0" y="263.3333333333333" width="38.0" height="116.66666666666667" fill="steelblue"/>
+<text x="300.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 300.0,395)" fill="white">sql</text>
+<rect x="320.0" y="263.3333333333333" width="38.0" height="116.66666666666667" fill="steelblue"/>
+<text x="340.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 340.0,395)" fill="white">developed</text>
+<rect x="360.0" y="263.3333333333333" width="38.0" height="116.66666666666667" fill="steelblue"/>
+<text x="380.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 380.0,395)" fill="white">a</text>
+<rect x="400.0" y="292.5" width="38.0" height="87.5" fill="steelblue"/>
+<text x="420.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 420.0,395)" fill="white">2020</text>
+<rect x="440.0" y="292.5" width="38.0" height="87.5" fill="steelblue"/>
+<text x="460.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 460.0,395)" fill="white">2022</text>
+<rect x="480.0" y="292.5" width="38.0" height="87.5" fill="steelblue"/>
+<text x="500.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 500.0,395)" fill="white">with</text>
+<rect x="520.0" y="292.5" width="38.0" height="87.5" fill="steelblue"/>
+<text x="540.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 540.0,395)" fill="white">real</text>
+<rect x="560.0" y="292.5" width="38.0" height="87.5" fill="steelblue"/>
+<text x="580.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 580.0,395)" fill="white">music</text>
+<rect x="600.0" y="292.5" width="38.0" height="87.5" fill="steelblue"/>
+<text x="620.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 620.0,395)" fill="white">streaming</text>
+<rect x="640.0" y="292.5" width="38.0" height="87.5" fill="steelblue"/>
+<text x="660.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 660.0,395)" fill="white">designed</text>
+<rect x="680.0" y="292.5" width="38.0" height="87.5" fill="steelblue"/>
+<text x="700.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 700.0,395)" fill="white">data</text>
+<rect x="720.0" y="292.5" width="38.0" height="87.5" fill="steelblue"/>
+<text x="740.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 740.0,395)" fill="white">c</text>
+<rect x="760.0" y="292.5" width="38.0" height="87.5" fill="steelblue"/>
+<text x="780.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 780.0,395)" fill="white">2019</text>
+</svg>

--- a/quiz1/Q2/figures/specific_words.svg
+++ b/quiz1/Q2/figures/specific_words.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">
+<text x="400.0" y="20" text-anchor="middle" font-size="16" fill="white">Top 20 Specific Words</text>
+<rect x="0.0" y="30.0" width="38.0" height="350.0" fill="steelblue"/>
+<text x="20.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 20.0,395)" fill="white">python</text>
+<rect x="40.0" y="180.0" width="38.0" height="200.0" fill="steelblue"/>
+<text x="60.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 60.0,395)" fill="white">software</text>
+<rect x="80.0" y="180.0" width="38.0" height="200.0" fill="steelblue"/>
+<text x="100.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 100.0,395)" fill="white">sql</text>
+<rect x="120.0" y="180.0" width="38.0" height="200.0" fill="steelblue"/>
+<text x="140.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 140.0,395)" fill="white">developed</text>
+<rect x="160.0" y="230.0" width="38.0" height="150.0" fill="steelblue"/>
+<text x="180.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 180.0,395)" fill="white">2020</text>
+<rect x="200.0" y="230.0" width="38.0" height="150.0" fill="steelblue"/>
+<text x="220.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 220.0,395)" fill="white">2022</text>
+<rect x="240.0" y="230.0" width="38.0" height="150.0" fill="steelblue"/>
+<text x="260.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 260.0,395)" fill="white">real</text>
+<rect x="280.0" y="230.0" width="38.0" height="150.0" fill="steelblue"/>
+<text x="300.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 300.0,395)" fill="white">music</text>
+<rect x="320.0" y="230.0" width="38.0" height="150.0" fill="steelblue"/>
+<text x="340.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 340.0,395)" fill="white">streaming</text>
+<rect x="360.0" y="230.0" width="38.0" height="150.0" fill="steelblue"/>
+<text x="380.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 380.0,395)" fill="white">designed</text>
+<rect x="400.0" y="230.0" width="38.0" height="150.0" fill="steelblue"/>
+<text x="420.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 420.0,395)" fill="white">data</text>
+<rect x="440.0" y="230.0" width="38.0" height="150.0" fill="steelblue"/>
+<text x="460.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 460.0,395)" fill="white">c</text>
+<rect x="480.0" y="230.0" width="38.0" height="150.0" fill="steelblue"/>
+<text x="500.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 500.0,395)" fill="white">2019</text>
+<rect x="520.0" y="280.0" width="38.0" height="100.0" fill="steelblue"/>
+<text x="540.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 540.0,395)" fill="white">suprawee</text>
+<rect x="560.0" y="280.0" width="38.0" height="100.0" fill="steelblue"/>
+<text x="580.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 580.0,395)" fill="white">columbia</text>
+<rect x="600.0" y="280.0" width="38.0" height="100.0" fill="steelblue"/>
+<text x="620.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 620.0,395)" fill="white">sc</text>
+<rect x="640.0" y="280.0" width="38.0" height="100.0" fill="steelblue"/>
+<text x="660.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 660.0,395)" fill="white">com</text>
+<rect x="680.0" y="280.0" width="38.0" height="100.0" fill="steelblue"/>
+<text x="700.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 700.0,395)" fill="white">university</text>
+<rect x="720.0" y="280.0" width="38.0" height="100.0" fill="steelblue"/>
+<text x="740.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 740.0,395)" fill="white">2023</text>
+<rect x="760.0" y="280.0" width="38.0" height="100.0" fill="steelblue"/>
+<text x="780.0" y="395" text-anchor="middle" font-size="10" transform="rotate(45 780.0,395)" fill="white">bachelor</text>
+</svg>


### PR DESCRIPTION
## Summary
- add student resume text
- analyze resume word frequencies and remove stop words
- generate SVG bar charts for raw and filtered words
- brighten chart labels with white text for readability

## Testing
- `python - <<'PY' ...` to regenerate SVG figures
- `pytest`
- `pip install matplotlib` *(fails: Could not find a version that satisfies the requirement matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_68c6df9c0b5083339ee2ebdb5bc173ed