### PR TITLE
Add class resume analysis

### DIFF
--- a/quiz1/Q2-code.ipynb
+++ b/quiz1/Q2-code.ipynb
@@ -68,6 +68,80 @@
    "source": [
     "Removing common stop words reveals keywords that emphasize technical skills and experiences, such as **developed**, **python**, and **project**, giving more insight into the resume's content."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Class Resume Word Analysis\n",
+    "Analyze word usage across all resumes in the class.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from PyPDF2 import PdfReader\n",
+    "resumes_dir = Path('Q2/data/resumes')\n",
+    "all_text = []\n",
+    "for pdf_path in sorted(resumes_dir.glob('*.pdf')):\n",
+    "    try:\n",
+    "        reader = PdfReader(str(pdf_path))\n",
+    "        text = ''\n",
+    "        for page in reader.pages:\n",
+    "            text += page.extract_text() or ''\n",
+    "        all_text.append(text)\n",
+    "    except Exception as e:\n",
+    "        print(f'Failed to read {pdf_path}: {e}')\n",
+    "class_text = '\n'.join(all_text)\n",
+    "Path('Q2/data/resumes_text.txt').write_text(class_text, encoding='utf-8')\n",
+    "class_words = re.findall(r'\\b\\w+\\b', class_text.lower())\n",
+    "class_counts = Counter(class_words)\n",
+    "top_class = class_counts.most_common(20)\n",
+    "save_svg_bar(top_class, figures_dir/'class_resume_words.svg', 'Top 20 Resume Words (Class)')\n",
+    "top_class[:5]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class_specific_words = [w for w in class_words if w not in stop_words]\n",
+    "class_specific_counts = Counter(class_specific_words)\n",
+    "top_class_specific = class_specific_counts.most_common(20)\n",
+    "save_svg_bar(top_class_specific, figures_dir/'class_specific_words.svg', 'Top 20 Specific Words (Class)')\n",
+    "top_class_specific[:5]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Removing stop words across all resumes highlights technical and domain-specific terms that reflect common skills among classmates.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_specific_set = set(specific_words)\n",
+    "class_specific_set = set(class_specific_words)\n",
+    "unique_words = sorted(my_specific_set - class_specific_set)[:20]\n",
+    "unique_words\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These words appear only in my resume, distinguishing my experiences from those of classmates.\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- Analyze word usage across all class resumes
- Visualize top words before and after stop-word removal
- Identify words unique to my resume compared to the class

## Testing
- `pip install PyPDF2` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c77741894c833382e04d31fc12e4a8